### PR TITLE
Reduce polling intervals to 30ms

### DIFF
--- a/Sources/SmartTaskbar.Win10.Hook/InjectionEntryPoint.cs
+++ b/Sources/SmartTaskbar.Win10.Hook/InjectionEntryPoint.cs
@@ -28,11 +28,16 @@ namespace SmartTaskbar.Hook
             _server.Ping();
             try
             {
+                var lastPing = Environment.TickCount;
                 while (true)
                 {
-                    Thread.Sleep(1000);
+                    Thread.Sleep(30);
 
-                    _server.Ping();
+                    if (Environment.TickCount - lastPing >= 1000)
+                    {
+                        _server.Ping();
+                        lastPing = Environment.TickCount;
+                    }
                 }
             }
             finally

--- a/Sources/SmartTaskbar.Win10/Worker/Engine.cs
+++ b/Sources/SmartTaskbar.Win10/Worker/Engine.cs
@@ -23,10 +23,11 @@ namespace SmartTaskbar
 
         public Engine(Container container)
         {
-            // 125 milliseconds is a balance between user-acceptable perception and system call time.
+            // Poll every 30 milliseconds and rely on counters to keep the
+            // overall behaviour consistent with the previous timings.
             _timer = new Timer(container)
             {
-                Interval = 125
+                Interval = 30
             };
             _timer.Tick += Timer_Tick;
             _timer.Start();
@@ -37,8 +38,8 @@ namespace SmartTaskbar
             if (UserSettings.AutoModeType != AutoModeType.Auto)
                 return;
 
-            // get taskbar every 1.25 second.
-            if (_timerCount % 5 == 0)
+            // get taskbar roughly every 0.63 second.
+            if (_timerCount % 21 == 0)
             {
                 // Make sure the taskbar has been automatically hidden, otherwise it will not work
                 Fun.SetAutoHide();
@@ -79,7 +80,7 @@ namespace SmartTaskbar
             ++_timerCount;
 
             // clear cache and reset stable every 15 min.
-            if (_timerCount <= 7200) return;
+            if (_timerCount <= 30000) return;
 
             _timerCount = 0;
 
@@ -125,7 +126,7 @@ namespace SmartTaskbar
                     break;
                 case TaskbarBehavior.Hide:
                     if (info == _currentForegroundWindow
-                        && _hidingCount == 5)
+                        && _hidingCount == 21)
                         return;
 
                     #if DEBUG
@@ -178,7 +179,7 @@ namespace SmartTaskbar
                     break;
                 case TaskbarBehavior.Hide:
                     if (info == _currentForegroundWindow
-                        && _hidingCount == 5)
+                        && _hidingCount == 21)
                         return;
 
                     // Some third-party taskbar plugins will be attached to the taskbar location, but not embedded in the taskbar or desktop.

--- a/Sources/SmartTaskbar/Worker/Engine.cs
+++ b/Sources/SmartTaskbar/Worker/Engine.cs
@@ -21,10 +21,11 @@ namespace SmartTaskbar
 
         public Engine(Container container)
         {
-            // 125 milliseconds is a balance between user-acceptable perception and system call time.
+            // Poll every 30 milliseconds and use counters to preserve the
+            // previous timing behaviour while staying within the 30ms limit.
             _timer = new Timer(container)
             {
-                Interval = 125
+                Interval = 30
             };
             _timer.Tick += Timer_Tick;
             _timer.Start();
@@ -35,8 +36,8 @@ namespace SmartTaskbar
             if (UserSettings.AutoModeType != AutoModeType.Auto)
                 return;
 
-            // get taskbar every 1.25 second.
-            if (_timerCount % 5 == 0)
+            // get taskbar roughly every 0.63 second.
+            if (_timerCount % 21 == 0)
             {
                 // Make sure the taskbar has been automatically hidden, otherwise it will not work
                 Fun.SetAutoHide();
@@ -69,7 +70,7 @@ namespace SmartTaskbar
             ++_timerCount;
 
             // clear cache and reset stable every 15 min.
-            if (_timerCount <= 7200) return;
+            if (_timerCount <= 30000) return;
 
             _timerCount = 0;
 


### PR DESCRIPTION
## Summary
- Lower all timer and sleep based polling intervals to 30ms
- Maintain original logic using counters to keep prior effective timing
- Ensure hook ping loop sleeps 30ms and pings approximately once per second

## Testing
- `dotnet build Sources/SmartTaskbar.sln` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden while trying to update packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cc847fa483329dbc9b26b815f3d1